### PR TITLE
Update Navbar.astro

### DIFF
--- a/src/layouts/Navbar.astro
+++ b/src/layouts/Navbar.astro
@@ -26,6 +26,7 @@ interface Props {
       </a>
       <a href="https://www.daxa.dev/">
         <svg
+          style="overflow: visible;"
           class="h-5 fill-gray-900 dark:fill-gray-100"
           viewBox="0 0 10.03473 2.6050849"
           version="1.1"
@@ -43,6 +44,7 @@ interface Props {
           <>
             <a href="https://wiki.daxa.dev/">
               <svg
+                style="overflow: visible;"
                 class="h-5 fill-primary-700 dark:fill-primary-500"
                 viewBox="0 0 7.8365781 2.6050849"
                 version="1.1"


### PR DESCRIPTION
This change fixes the clipping on the daxa logo without changing any of the assets.

After:
![image](https://github.com/user-attachments/assets/dc3f1752-4cc5-496e-a495-9caf3e7687df)

Before:
![image](https://github.com/user-attachments/assets/898bd4a0-b57f-435d-a34a-7badc46a8f48)
